### PR TITLE
Allow local_serial/serial consistencies for read consistency.

### DIFF
--- a/src/cqerl_protocol.erl
+++ b/src/cqerl_protocol.erl
@@ -52,7 +52,9 @@ encode_consistency_name(quorum)       -> ?CQERL_CONSISTENCY_QUORUM;
 encode_consistency_name(all)          -> ?CQERL_CONSISTENCY_ALL;
 encode_consistency_name(local_quorum) -> ?CQERL_CONSISTENCY_LOCAL_QUORUM;
 encode_consistency_name(each_quorum)  -> ?CQERL_CONSISTENCY_EACH_QUORUM;
-encode_consistency_name(local_one)    -> ?CQERL_CONSISTENCY_LOCAL_ONE.
+encode_consistency_name(local_one)    -> ?CQERL_CONSISTENCY_LOCAL_ONE;
+encode_consistency_name(local_serial) -> ?CQERL_CONSISTENCY_LOCAL_SERIAL;
+encode_consistency_name(serial)       -> ?CQERL_CONSISTENCY_SERIAL.
 
 -spec encode_serial_consistency_name(serial_consistency() | serial_consistency_int() | undefined) -> 0 | serial_consistency_int().
 encode_serial_consistency_name(Name) when is_integer(Name) -> Name;

--- a/test/cqerl_protocol_tests.erl
+++ b/test/cqerl_protocol_tests.erl
@@ -37,7 +37,9 @@ query_consistency_level_encoding_test() ->
     assert_query_consistency(?CQERL_CONSISTENCY_ALL,          all),
     assert_query_consistency(?CQERL_CONSISTENCY_LOCAL_QUORUM, local_quorum),
     assert_query_consistency(?CQERL_CONSISTENCY_EACH_QUORUM,  each_quorum),
-    assert_query_consistency(?CQERL_CONSISTENCY_LOCAL_ONE,    local_one).
+    assert_query_consistency(?CQERL_CONSISTENCY_LOCAL_ONE,    local_one),
+    assert_query_consistency(?CQERL_CONSISTENCY_LOCAL_SERIAL, local_serial),
+    assert_query_consistency(?CQERL_CONSISTENCY_SERIAL,       serial).
 
 query_serial_consistency_encoding_test() ->
     assert_query_serial_consistency(0,                               undefined),
@@ -53,7 +55,9 @@ batch_consistency_level_encoding_test() ->
     assert_batch_consistency(?CQERL_CONSISTENCY_ALL,          all),
     assert_batch_consistency(?CQERL_CONSISTENCY_LOCAL_QUORUM, local_quorum),
     assert_batch_consistency(?CQERL_CONSISTENCY_EACH_QUORUM,  each_quorum),
-    assert_batch_consistency(?CQERL_CONSISTENCY_LOCAL_ONE,    local_one).
+    assert_batch_consistency(?CQERL_CONSISTENCY_LOCAL_ONE,    local_one),
+    assert_batch_consistency(?CQERL_CONSISTENCY_LOCAL_SERIAL, local_serial),
+    assert_batch_consistency(?CQERL_CONSISTENCY_SERIAL,       serial).
 
 batch_mode_encoding_test() ->
     assert_batch_mode(?CQERL_BATCH_COUNTER,  counter),


### PR DESCRIPTION
As per documentation https://docs.datastax.com/en/cassandra-oss/2.2/cassandra/dml/dmlConfigConsistency.html both `LOCAL_SERIAL` and `SERIAL` are allowed levels for `CONSISTENCY` doing Read operations (to make sure read is done after all pending writes in LWT). 

Currently there's a workaround to use integer instead of atom, but this is nice QoL change ;) 